### PR TITLE
Add grugbot420 to Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - **[LangGraph](https://langchain.com)** 🆕🆓 - Stateful agent workflows
 - **[AutoGen](https://microsoft.github.io/autogen/)** 🆕🆓 - Microsoft's multi-agent framework
 - **[Semantic Kernel](https://github.com/microsoft/semantic-kernel)** 🆓 - AI orchestration SDK
+- **[grugbot420](https://github.com/grug-group420/grugbot420)** 🆓 - Neuromorphic cognitive engine in Julia for multi-model AI orchestration
 
 
 ## Photo Editing


### PR DESCRIPTION
## Addition: grugbot420

**Repository:** https://github.com/grug-group420/grugbot420  
**Category:** Agent Frameworks  
**License:** MIT | **Language:** Julia

A neuromorphic cognitive engine for multi-model AI orchestration. Deploys domain-expert AI specimens through architectural configuration rather than traditional training. Open source and free.