### PR TITLE
Add KidsFunLearnClub — free AI education platform for kids 9–14

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - **[Socratic by Google](https://socratic.org)** 🆓 - AI homework helper
 - **[Quizlet](https://quizlet.com)** 🔄 - AI-powered study tools
 - **[Coursera Coach](https://coursera.org)** 🔄 - AI learning assistant
+- **[KidsFunLearnClub](https://kidsfunlearnclub.co)** 🆓 - Free AI education platform for kids 9–14, taught by an 11-year-old certified AI educator
 
 #### 📚 Research & Writing
 - **[Elicit](https://elicit.org)** 🔄 - AI research assistant


### PR DESCRIPTION
## What's being added

**[KidsFunLearnClub](https://kidsfunlearnclub.co)** — a free AI education platform for kids aged 9–14.

Added to the **Education Assistants → Study & Learning** section.

## Why it fits

- 🆓 Completely free — no paywall, no account required
- 130+ posts covering AI concepts for kids (machine learning, bias in data, reinforcement learning, prompt engineering, generative AI)
- Created and taught by Parikshet, an 11-year-old certified AI educator from Dubai (certified under HH Sheikh Hamdan's 1 Million Prompters initiative)
- Students in 40+ countries; 6,170+ YouTube subscribers
- Content mapped to hands-on tools: Teachable Machine, Code.org AI for Oceans, MIT Scratch ML

## Checklist

- [x] Tool actually uses AI/ML
- [x] Currently active and maintained
- [x] Completely free (🆓)
- [x] Description under 100 characters
- [x] Tested and verified working