### PR TITLE
Add CreatorSkills to Content Creation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - **[Asterix Writer](https://asterixwriter.com)** 🔄 - Fiction and story writing
 
 #### 📝 Content Creation
+- **[CreatorSkills](https://creatorskills.co)** 💰 - Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.
 - **[Frase](https://frase.io)** 🔄 - SEO-optimized content writing
 - **[WritingMate](https://writingmate.ai)** 🔄 - AI writing companion
 - **[Neural Newsletters](https://neuralnewsletters.com)** 🔄 - Newsletter generation


### PR DESCRIPTION
## Summary

Adds [CreatorSkills](https://creatorskills.co) to the **📝 Content Creation** subsection under Writing.

CreatorSkills is a curated marketplace of 30+ downloadable AI skills purpose-built for content creators — YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Unlike standalone AI writers, these skills plug directly into Claude, ChatGPT, and 20+ AI platforms users already have, giving their AI specialized domain knowledge for content creation workflows.

Fits naturally alongside Frase, WritingMate, and Neural Newsletters in the Content Creation subsection.