### PR TITLE
Add GPT Image 2 to Text to Image AI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - **[DreamStudio](https://dreamstudio.ai)** 🔄 - Stability AI's official interface
 - **[NightCafe](https://nightcafe.studio)** 🔄 - Community-focused platform
 - **[Playground AI](https://playgroundai.com)** 🔄 - Creative AI with fine-tuning
+- **[GPT Image 2](https://gptimage2.asia)** 🔄 - AI image generation/editing for marketing, ecommerce and branded content
 - **[Tensor Art](https://tensor.art)** 🔄 - Community-driven AI art platform
 
 #### 🆕 Specialized Tools


### PR DESCRIPTION
## Summary
Adds GPT Image 2 to the Text to Image AI's > Freemium Options section.

Entry added:

- **[GPT Image 2](https://gptimage2.asia)** 🔄 - AI image generation/editing for marketing, ecommerce and branded content

Checklist:
- [x] Uses AI/ML as a core feature
- [x] Official website URL is accessible
- [x] Added to the appropriate existing category
- [x] Description is brief and specific
- [x] Searched for existing target URL before submitting

Disclosure: submitted by the project owner/operator.