### PR TITLE
Add Eimu - online GPT Image 2 & Nano Banana Pro generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - **[Craiyon](https://www.craiyon.com)** 🆓 - Free and easy-to-use generator
 
 #### 🔄 Freemium Options
+- **[Emu](https://image.tinchak0207.xyz)** 🔄 - Online GPT Image 2 & Nano Banana Pro image generator, no API key or relay setup required
 - **[Ideogram 3.0](https://ideogram.ai)** 🆕🔄 - Best text rendering in images (March 2025)
 - **[Reve Image](https://reve.ai)** 🆕🔄 - Strong prompt adherence (March 2025)
 - **[DreamStudio](https://dreamstudio.ai)** 🔄 - Stability AI's official interface

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - **[Craiyon](https://www.craiyon.com)** 🆓 - Free and easy-to-use generator
 
 #### 🔄 Freemium Options
-- **[Emu](https://image.tinchak0207.xyz)** 🔄 - Online GPT Image 2 & Nano Banana Pro image generator, no API key or relay setup required
+- **[Eimu](https://eimu.art)** 🔄 - Online GPT Image 2 & Nano Banana Pro image generator, no API key or relay setup required
 - **[Ideogram 3.0](https://ideogram.ai)** 🆕🔄 - Best text rendering in images (March 2025)
 - **[Reve Image](https://reve.ai)** 🆕🔄 - Strong prompt adherence (March 2025)
 - **[DreamStudio](https://dreamstudio.ai)** 🔄 - Stability AI's official interface


### PR DESCRIPTION
Add [Eimu](https://eimu.art) to the Text to Image / Freemium Options section.

Online image generation tool for GPT Image 2 / Nano Banana Pro style images - sign in, type a prompt, download. No relay station setup or API key required. Offers OpenAI-compatible generation API and MCP integration.

Docs: https://eimu.art/docs