### PR TITLE
Add videos.social to Video Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - **[Synthesia](https://synthesia.io)** 💰 - AI avatar video generation
 - **[HeyGen](https://heygen.com)** 🔄 - AI avatar videos with lip sync
 - **[Fliki](https://fliki.ai)** 🔄 - Text-to-video with AI voices
+- **[videos.social](https://videos.social/?utm_source=ai-catalog&utm_medium=directory&utm_campaign=listing-wave-d)** 🔄 - Editable faceless video from blogs, PDFs, and prompts
 - **[Descript](https://descript.com)** 🔄 - AI-powered video editing
 - **[Klap](https://klap.app)** 🔄 - Turn videos into viral clips
 - **[OpusClip](https://opus.pro)** 🆕🔄 - Auto short clips from long videos


### PR DESCRIPTION
Adds videos.social under **Video Generator → Content Creation**, next to Fliki / Synthesia / HeyGen.

videos.social turns blogs, PDFs, and prompts into editable faceless videos (script, scenes, voiceover) rather than a locked regenerate loop. Start free — 1 render included. Packs from $10. 1 credit = 1 render.

Public, usable product in the same class as Fliki. Not a duplicate. Freemium (🔄).

Disclosure: submitted by the videos.social team.
