### PR TITLE
Add Persona to Self-Hosted Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 #### 🛠️ Self-Hosted Options
 - **[AI Runner](https://github.com/Capsize-Games/airunner)** 🆓 - Local AI model runner with GUI
 - **[Jan](https://jan.ai)** 🆓 - Open-source ChatGPT alternative
+- **[Persona](https://github.com/jayamitkatariya/personacli)** 🆓 - Local-first personal workspace with notes, tasks, and grounded AI chat in plain Markdown
 
 ---
 


### PR DESCRIPTION
Adds [Persona](https://github.com/jayamitkatariya/personacli) to **AI Assistants & Chat → Self-Hosted Options**.

Persona is a local-first personal workspace: notes and tasks as plain Markdown, with an AI chat grounded in your own files. Free, open-source (MIT), runs on Ollama or any OpenAI-compatible API.