### PR TITLE
Add Luphra to 3D tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - **[Deepshot AI](https://deepshot.ai)** 🔄 - Video reshooting tool
 ## 3D
 - Meshy
+- [Luphra](https://www.luphra.com)
 - StudioGPT
 - Pixela AI
 - Get 3D (nvidia)


### PR DESCRIPTION
## Summary
- Adds [Luphra](https://www.luphra.com) under the **3D** section (after Meshy).
- Luphra is prompt-to-matter AI: turns prompts/sketches into editable 3D and manufactured physical products (starting with 3D printables). Freemium.

## Test plan
- [ ] Confirm Luphra is not already listed elsewhere in README
- [ ] Confirm link https://www.luphra.com resolves