### PR TITLE
Add ResumeAI under Builder (resume)

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 ## Builder
 - [Ai chatbot builder](http://Wizy.chat)
 - [Ai resume builder](http://Kickresume.com)
+- [ResumeAI](https://withresumeai.com/) - Free ATS checker + AI resume builder
 
 ## Landing Page Generator
 - [aipage.dev](https://www.aipage.dev)


### PR DESCRIPTION
Adds [ResumeAI](https://withresumeai.com/) — AI resume builder with a free ATS checker (3 checks/day with no account) — and links the open [State of ATS 2026](https://github.com/Kayvan-Zahiri/state-of-ats-2026) dataset (738 large employers, 704 portal-verified; Workday share 37.9%).

Happy to adjust placement or wording.