### PR TITLE
Add Orkas to open source agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - **[Manus AI](https://manus.ai)** 🆕🔄 - Cloud-based autonomous system
 
 #### 🆓 Open Source Agents
+- **[Orkas](https://github.com/Orkas-AI/Orkas)** 🆓 - Local-first desktop AI workforce coordinated by a Commander through one chat
 - **[AutoGPT](https://github.com/Significant-Gravitas/AutoGPT)** 🆓 - GPT-4 powered autonomous agent
 - **[BabyAGI](https://github.com/yoheinakajima/babyagi)** 🆓 - Minimalist AI agent framework
 - **[CrewAI](https://github.com/joaomdmoura/crewAI)** 🆕🆓 - Multi-agent orchestration


### PR DESCRIPTION
## Description

Adds Orkas to the Open Source Agents section with a concise description and its canonical GitHub repository.

## Checklist

- [x] Added in the relevant category
- [x] Description is under 100 characters and follows the existing format
- [x] Link was opened and verified
- [x] No duplicate entry exists

## Additional notes

I am affiliated with Orkas. The project is open source and the link has no tracking parameters.